### PR TITLE
Fix initializing and acknowledging unreliable connections

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -536,6 +536,15 @@ impl Client {
                     self.sctp_remote_tsn = new_cumulative_tsn;
                 }
                 SctpChunk::InitAck { .. } | SctpChunk::CookieAck => {}
+                SctpChunk::Error {
+                    first_param_type,
+                    first_param_data,
+                } => {
+                    warn!(
+                        "SCTP error chunk received: {} {:?}",
+                        first_param_type, first_param_data
+                    );
+                }
                 chunk => debug!("unhandled SCTP chunk {:?}", chunk),
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -359,7 +359,14 @@ impl Client {
                     num_outbound_streams,
                     num_inbound_streams,
                     initial_tsn,
+                    support_unreliable,
                 } => {
+                    if !support_unreliable {
+                        warn!("peer does not support selective unreliability, abort connection");
+                        self.sctp_state = SctpState::Shutdown;
+                        return self.start_shutdown();
+                    }
+
                     let mut rng = thread_rng();
 
                     self.sctp_local_port = sctp_packet.dest_port;
@@ -450,7 +457,8 @@ impl Client {
                     } else if proto_id == DATA_CHANNEL_PROTO_BINARY {
                         let mut msg_buffer = ssl_stream.get_ref().buffer_pool.acquire();
                         msg_buffer.extend(user_data);
-                        self.received_messages.push((MessageType::Binary, msg_buffer));
+                        self.received_messages
+                            .push((MessageType::Binary, msg_buffer));
                     }
 
                     send_sctp_packet(


### PR DESCRIPTION
A few changes:

1. Check that incoming connections provide the forward tsn parameter in INIT, and otherwise abort the incoming connection entirely. Since this _is_ webrtc-unreliable, not webrtc-_optionally_unreliable.
2. Clean up a potential issue in reading the state cookie from incoming init acks
3. On firefox the SCTP connection would not accept FORWARD TSN unless the forward tsn parameter was explicitly provided in INIT ACK. Make it so the forward tsn parameter is always written to INIT ACK.
4. Add a bit of error logging for incoming ERROR messages since that's what exposed the problem in the first place.

If printing warn messages in places where it can be abused by clients (spamming ERROR messages to force the server to log error messages, or sending INIT messages without the forward tsn provided) is a problem I can remove those.