### PR TITLE
Remove unnecessary spawn in example.

### DIFF
--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -58,9 +58,8 @@ async fn main() {
         .parse()
         .expect("could not parse HTTP address/port");
 
-    let mut rtc_server = tokio::spawn(RtcServer::new(webrtc_listen_addr, public_webrtc_addr))
+    let mut rtc_server = RtcServer::new(webrtc_listen_addr, public_webrtc_addr)
         .await
-        .unwrap()
         .expect("could not start RTC server");
 
     let session_endpoint = rtc_server.session_endpoint();


### PR DESCRIPTION
It's not necessary to spawn and join a separate task to create the Server instance.

(Thanks for doing all this. This is really cool stuff! I want to try build something with it, and hope I can be useful in the process.) 😃