### PR TITLE
Change dependency crc32c to crc to enable ARM build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [dependencies]
 byteorder = "1.3"
-crc32c = "0.4"
+crc = "1.8.1"
 crc32fast = "1.2"
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }


### PR DESCRIPTION
Hi, first, thanks for this crate!

I don't know if I am the first person to encounter this issue, but this crate can only be built on x86 arch because of the [crc32c](https://github.com/zowens/crc32c) dependency. This is a known issue zowens/crc32c#11. However, this crate does not seem to be getting much interest or really active.

I found [crc-rc](https://github.com/mrhooray/crc-rs) which even if not updated in the last 5 months is at his version 1.8. So, I assume it is ready for production and might be used as a dependency.

I can understand that you had your own reason to use `crc32c` and that you do not want to change.