### PR TITLE
Connection and disconnection events

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,5 @@ mod server;
 mod stun;
 mod util;
 
-pub use client::{MessageType, MAX_MESSAGE_LEN};
+pub use client::{MessageType, ClientEvent, MAX_MESSAGE_LEN};
 pub use server::{MessageResult, RecvError, SendError, Server, SessionEndpoint};


### PR DESCRIPTION
Hey there! This PR is to introduce a new public method on the Server impl, "get_event_receiver()" which optionally sets up a channel that will emit connection & disconnection events.

Idk if this is something you're interested in adding to the API, but it became necessary for my own project and maybe someone else can take advantage of it. Please give me some recommendations as I'm still learning Rust, totally down for a refactor. This is my first Rust PR!

oh btw, this crate rocks!