### PR TITLE
Support sharing a Crypto instance between Server instances

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,21 +1,20 @@
-use std::fmt::Write as _;
+use std::{fmt::Write as _, sync::Arc};
 
 use openssl::{
     asn1::Asn1Time,
     error::ErrorStack,
     hash::MessageDigest,
     nid::Nid,
-    pkey::{PKey, Private},
+    pkey::PKey,
     rsa::Rsa,
     ssl::{SslAcceptor, SslMethod, SslVerifyMode},
     x509::{X509NameBuilder, X509},
 };
 
+#[derive(Clone)]
 pub struct Crypto {
-    pub key: PKey<Private>,
-    pub x509: X509,
-    pub fingerprint: String,
-    pub ssl_acceptor: SslAcceptor,
+    pub(crate) fingerprint: String,
+    pub(crate) ssl_acceptor: Arc<SslAcceptor>,
 }
 
 impl Crypto {
@@ -72,11 +71,9 @@ impl Crypto {
 
         ssl_acceptor_builder.set_private_key(&key)?;
         ssl_acceptor_builder.set_certificate(&x509)?;
-        let ssl_acceptor = ssl_acceptor_builder.build();
+        let ssl_acceptor = Arc::new(ssl_acceptor_builder.build());
 
         Ok(Crypto {
-            key,
-            x509,
             fingerprint,
             ssl_acceptor,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod stun;
 mod util;
 
 pub use client::{MessageType, MAX_MESSAGE_LEN};
+pub use crypto::Crypto;
 pub use server::{MessageBuffer, MessageResult, SendError, Server, SessionEndpoint};
 
 #[cfg(feature = "tokio")]


### PR DESCRIPTION
This addresses an issue where connecting to multiple Server instances from a single tab in Firefox would result in an SSL handshake error. Using the same certificate across all `Server` instances fixes the issue, so I've implemented a way of doing that.

I opted to share the entire `openssl::SslConnector` since it can be trivially wrapped in an `Arc`. I exposed the `Crypto` type but kept it opaque, and added a `Server::with_crypto` constructor to optionally allow passing in a `Crypto` instance.

Usage example:
```rust
// Create a new Crypto instance, creating a new certificate
let crypto = Crypto::init().expect("WebRTC server could not initialize OpenSSL primitives");
// Instantiate two servers sharing the same Crypto instance
let server1 = Server::with_crypto(listen_addr, public_addr, crypto.clone()).await.unwrap();
let server2 = Server::with_crypto(listen_addr, public_addr, crypto).await.unwrap();
```

I can change it to a constructor that takes an `openssl::pkey::PKey` if you prefer not exposing `Crypto`. Would give the user more flexibility but a more complicated API.

I can also change the `Server::with_crypto` constructor to be a builder API or something if you prefer.

I'll add doc comments when the API is decided.