### PR TITLE
Generate a random serial each time a cert is generated

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -10,7 +10,7 @@ use openssl::{
     pkey::PKey,
     rsa::Rsa,
     ssl::{SslAcceptor, SslMethod, SslVerifyMode},
-    x509::{X509NameBuilder, X509}
+    x509::{X509NameBuilder, X509},
 };
 
 /// A TLS private / public key pair and certificate.

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,7 +1,16 @@
 use std::{fmt::Write as _, sync::Arc};
 
 use openssl::{
-    asn1::Asn1Time, bn::BigNum, bn::MsbOption, error::ErrorStack, hash::MessageDigest, nid::Nid, pkey::PKey, rsa::Rsa, ssl::{SslAcceptor, SslMethod, SslVerifyMode}, x509::{X509NameBuilder, X509}
+    asn1::Asn1Time,
+    bn::BigNum,
+    bn::MsbOption,
+    error::ErrorStack,
+    hash::MessageDigest,
+    nid::Nid,
+    pkey::PKey,
+    rsa::Rsa,
+    ssl::{SslAcceptor, SslMethod, SslVerifyMode},
+    x509::{X509NameBuilder, X509}
 };
 
 /// A TLS private / public key pair and certificate.

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,14 +1,7 @@
 use std::{fmt::Write as _, sync::Arc};
 
 use openssl::{
-    asn1::Asn1Time,
-    error::ErrorStack,
-    hash::MessageDigest,
-    nid::Nid,
-    pkey::PKey,
-    rsa::Rsa,
-    ssl::{SslAcceptor, SslMethod, SslVerifyMode},
-    x509::{X509NameBuilder, X509},
+    asn1::Asn1Time, bn::BigNum, bn::MsbOption, error::ErrorStack, hash::MessageDigest, nid::Nid, pkey::PKey, rsa::Rsa, ssl::{SslAcceptor, SslMethod, SslVerifyMode}, x509::{X509NameBuilder, X509}
 };
 
 /// A TLS private / public key pair and certificate.
@@ -50,6 +43,9 @@ impl SslConfig {
         x509_builder.set_version(2)?;
         x509_builder.set_subject_name(&name)?;
         x509_builder.set_issuer_name(&name)?;
+        let mut serial = BigNum::new().unwrap();
+        serial.rand(128, MsbOption::MAYBE_ZERO, false).unwrap();
+        x509_builder.set_serial_number(&serial.to_asn1_integer().unwrap())?;
         let not_before = Asn1Time::days_from_now(X509_DAYS_NOT_BEFORE)?;
         let not_after = Asn1Time::days_from_now(X509_DAYS_NOT_AFTER)?;
         x509_builder.set_not_before(&not_before)?;


### PR DESCRIPTION
Some implementations of WebRTC/DTLS do not like it if the same serial and issuer name is on multiple certs for multiple servers connected at the same time. Firefox throws a "SEC_ERROR_REUSED_ISSUER_AND_SERIAL" error (once you enable enough tracing to be able to even see the error).

This generates a random serial when the cert is generated. Tested and allows Firefox to connect to multiple servers running webrtc-unreliable.

Should fix benhansen-io/pinging#2